### PR TITLE
feat: retrier and simplified DoRecover

### DIFF
--- a/recovererr.go
+++ b/recovererr.go
@@ -22,20 +22,17 @@ func Unrecoverable(err error) error {
 	return &recoverError{err: err}
 }
 
-// DoRecover can be used by error checkers to validate if error should be recovered.
-//
-// If the user marks errors as recoverable using `Recoverable(error)`, this function
-// should be used with fallback equal `false` because errors are unrecoverable by default
-// and recoverable are explicitly defined.
-// If the user marks errors as unrecoverable using `Unrecoverable(error)`, this function
-// should be used with fallback equal `true` because errors are recoverable by default
-// and unrecoverable are explicitly defined.
-func DoRecover(err error, fallback bool) bool {
+// DoRecover can be used by user to validate if error should be recovered.
+// When no recovery context is found in the given error, it returns
+// false in both values.
+// When recovery context is found in the given error, it returns
+// true in the first value and the recovery context of the error.
+func DoRecover(err error) (bool, bool) {
 	for err != nil {
 		if x, ok := err.(interface{ Recover() bool }); ok {
-			return x.Recover()
+			return true, x.Recover()
 		}
 		err = errors.Unwrap(err)
 	}
-	return fallback
+	return false, false
 }

--- a/recovererr_test.go
+++ b/recovererr_test.go
@@ -15,32 +15,44 @@ func TestDoRecover(t *testing.T) {
 	)
 	t.Run("recoverable wrapped error", func(t *testing.T) {
 		err := Recoverable(ConnectionError)
-		assert.True(t, DoRecover(err, false), err)
+		found, recover := DoRecover(err)
+		assert.True(t, found, err)
+		assert.True(t, recover, err)
 	})
 
 	t.Run("unrecoverable wrapped error", func(t *testing.T) {
 		err := Unrecoverable(ParseError)
-		assert.False(t, DoRecover(err, true), err)
+		found, recover := DoRecover(err)
+		assert.True(t, found, err)
+		assert.False(t, recover, err)
 	})
 
 	t.Run("recoverable wrapped error wrapped", func(t *testing.T) {
 		err := fmt.Errorf("failed to store object, %w", Recoverable(ConnectionError))
-		assert.True(t, DoRecover(err, false), err)
+		found, recover := DoRecover(err)
+		assert.True(t, found, err)
+		assert.True(t, recover, err)
 	})
 
 	t.Run("unrecoverable wrapped error", func(t *testing.T) {
 		err := fmt.Errorf("failed to parse object, %w", Unrecoverable(ParseError))
-		assert.False(t, DoRecover(err, true), err)
+		found, recover := DoRecover(err)
+		assert.True(t, found, err)
+		assert.False(t, recover, err)
 	})
 
 	t.Run("unrecoverable wrapped error", func(t *testing.T) {
 		err := &anyError{}
-		assert.False(t, DoRecover(err, false), err)
+		found, recover := DoRecover(err)
+		assert.False(t, found, err)
+		assert.False(t, recover, err)
 	})
 
 	t.Run("other recover error implementation", func(t *testing.T) {
 		err := &otherRecoverError{recover: true}
-		assert.True(t, DoRecover(err, false), err)
+		found, recover := DoRecover(err)
+		assert.True(t, found, err)
+		assert.True(t, recover, err)
 	})
 }
 

--- a/retrier.go
+++ b/retrier.go
@@ -1,0 +1,59 @@
+package recovererr
+
+import (
+	"context"
+	"time"
+)
+
+// func retry(ctx context.Context, f func() (bool, error), intervals <-chan time.Time) error {
+// 	for {
+// 		retry, err := f()
+// 		if err == nil {
+// 			return nil
+// 		}
+// 		if !retry {
+// 			return err
+// 		}
+
+// 		select {
+// 		case <-ctx.Done():
+// 			return ctx.Err()
+// 		case <-intervals:
+// 		}
+// 		// fmt.Println("will retry")
+// 	}
+// }
+
+func retry(ctx context.Context, f func() error, intervals <-chan time.Time, retryPolicy RetryPolicy) error {
+	for {
+		err := f()
+		if err == nil {
+			return nil
+		}
+		// exit if retry signals not retry
+		if !retryPolicy(err) {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-intervals:
+		}
+		// fmt.Println("will retry")
+	}
+}
+
+type RetryPolicy func(error) bool
+
+// RetryRecoverablePolicy will return retry if error is explicitly recoverable.
+// Any error with no recover context or non matching error will not be retried.
+func RetryRecoverablePolicy(err error) bool {
+	return DoRecover(err, false)
+}
+
+// SkipUnrecoverablePolicy will return not retry if error is explicitly unrecoverable.
+// Any error with no recover context will be retried.
+func SkipUnrecoverablePolicy(err error) bool {
+	return DoRecover(err, true)
+}

--- a/retrier.go
+++ b/retrier.go
@@ -46,14 +46,16 @@ func retry(ctx context.Context, f func() error, intervals <-chan time.Time, retr
 
 type RetryPolicy func(error) bool
 
-// RetryRecoverablePolicy will return retry if error is explicitly recoverable.
-// Any error with no recover context or non matching error will not be retried.
+// RetryRecoverablePolicy will return retry if error is recoverable
+// and not retry otherwise or for errors with no recovery context.
 func RetryRecoverablePolicy(err error) bool {
-	return DoRecover(err, false)
+	found, recover := DoRecover(err)
+	return found && recover
 }
 
-// SkipUnrecoverablePolicy will return not retry if error is explicitly unrecoverable.
-// Any error with no recover context will be retried.
-func SkipUnrecoverablePolicy(err error) bool {
-	return DoRecover(err, true)
+// RetryNonUnrecoverablePolicy will return retry if error is recoverable
+// or error with no recovery context is provided.
+func RetryNonUnrecoverablePolicy(err error) bool {
+	found, recover := DoRecover(err)
+	return !found || recover
 }

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -74,7 +74,7 @@ func Test_retry_retryRecoverablePolicy(t *testing.T) {
 	})
 }
 
-func Test_retry_skipUnrecoverablePolicy(t *testing.T) {
+func Test_retry_retryNonUnrecoverablePolicy(t *testing.T) {
 	t.Parallel()
 
 	t.Run("retry recoverable until cancellation", func(t *testing.T) {
@@ -83,7 +83,7 @@ func Test_retry_skipUnrecoverablePolicy(t *testing.T) {
 
 		recoverErrorAction := &action{errors: []error{Recoverable(errors.New("failure"))}}
 
-		retry(ctx, recoverErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+		retry(ctx, recoverErrorAction.Call, time.Tick(time.Millisecond), RetryNonUnrecoverablePolicy)
 
 		assert.True(t, recoverErrorAction.callCounter > 1)
 	})
@@ -94,7 +94,7 @@ func Test_retry_skipUnrecoverablePolicy(t *testing.T) {
 
 		anyErrorAction := &action{errors: []error{errors.New("failure")}}
 
-		retry(ctx, anyErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+		retry(ctx, anyErrorAction.Call, time.Tick(time.Millisecond), RetryNonUnrecoverablePolicy)
 
 		assert.True(t, anyErrorAction.callCounter > 0)
 	})
@@ -105,7 +105,7 @@ func Test_retry_skipUnrecoverablePolicy(t *testing.T) {
 
 		unrecoverableErrorAction := &action{errors: []error{Unrecoverable(errors.New("failure"))}}
 
-		retry(ctx, unrecoverableErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+		retry(ctx, unrecoverableErrorAction.Call, time.Tick(time.Millisecond), RetryNonUnrecoverablePolicy)
 
 		assert.Equal(t, 1, unrecoverableErrorAction.callCounter)
 	})
@@ -116,7 +116,7 @@ func Test_retry_skipUnrecoverablePolicy(t *testing.T) {
 
 		noErrorAction := &action{errors: []error{}}
 
-		retry(ctx, noErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+		retry(ctx, noErrorAction.Call, time.Tick(time.Millisecond), RetryNonUnrecoverablePolicy)
 
 		assert.Equal(t, 1, noErrorAction.callCounter)
 	})

--- a/retrier_test.go
+++ b/retrier_test.go
@@ -1,0 +1,123 @@
+package recovererr
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type action struct {
+	callCounter int
+	errors      []error
+}
+
+func (a *action) Call() error {
+	a.callCounter++
+	var err error
+	if len(a.errors) > 0 {
+		err = a.errors[0]
+	}
+	if len(a.errors) > 1 {
+		a.errors = a.errors[1:]
+	}
+	return err
+}
+
+func Test_retry_retryRecoverablePolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retry recoverable until cancellation", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		recoverErrorAction := &action{errors: []error{Recoverable(errors.New("failure"))}}
+
+		retry(ctx, recoverErrorAction.Call, time.Tick(time.Millisecond), RetryRecoverablePolicy)
+
+		assert.True(t, recoverErrorAction.callCounter > 1)
+	})
+
+	t.Run("no retry for any other error", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		anyErrorAction := &action{errors: []error{errors.New("failure")}}
+
+		retry(ctx, anyErrorAction.Call, time.Tick(time.Millisecond), RetryRecoverablePolicy)
+
+		assert.Equal(t, 1, anyErrorAction.callCounter)
+	})
+
+	t.Run("no retry for unrecoverable error", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		unrecoverableErrorAction := &action{errors: []error{Unrecoverable(errors.New("failure"))}}
+
+		retry(ctx, unrecoverableErrorAction.Call, time.Tick(time.Millisecond), RetryRecoverablePolicy)
+
+		assert.Equal(t, 1, unrecoverableErrorAction.callCounter)
+	})
+
+	t.Run("no retry on no error", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		noErrorAction := &action{errors: []error{}}
+
+		retry(ctx, noErrorAction.Call, time.Tick(time.Millisecond), RetryRecoverablePolicy)
+
+		assert.Equal(t, 1, noErrorAction.callCounter)
+	})
+}
+
+func Test_retry_skipUnrecoverablePolicy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retry recoverable until cancellation", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		recoverErrorAction := &action{errors: []error{Recoverable(errors.New("failure"))}}
+
+		retry(ctx, recoverErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+
+		assert.True(t, recoverErrorAction.callCounter > 1)
+	})
+
+	t.Run("retry any other error until cancellation", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		anyErrorAction := &action{errors: []error{errors.New("failure")}}
+
+		retry(ctx, anyErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+
+		assert.True(t, anyErrorAction.callCounter > 0)
+	})
+
+	t.Run("skip retry for unrecoverable error", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		unrecoverableErrorAction := &action{errors: []error{Unrecoverable(errors.New("failure"))}}
+
+		retry(ctx, unrecoverableErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+
+		assert.Equal(t, 1, unrecoverableErrorAction.callCounter)
+	})
+
+	t.Run("no retry on no error", func(t *testing.T) {
+		ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancelFunc()
+
+		noErrorAction := &action{errors: []error{}}
+
+		retry(ctx, noErrorAction.Call, time.Tick(time.Millisecond), SkipUnrecoverablePolicy)
+
+		assert.Equal(t, 1, noErrorAction.callCounter)
+	})
+}


### PR DESCRIPTION
`retrier` is a feature its own that could be in another module (maybe package at least). 
I add it here for code locality and to show the vision of errors with recovery context.

`DoRecover` input was simplified to accept single error argument, but return multiple values, to signal if not recovery context was found and the context itself. 

